### PR TITLE
Use RapidXMLParser to resolve LibXMLParser::xmlCleanupParser crash

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
             path: "svg-native-viewer",
             exclude: ["svgnative/src/win",
                       "svgnative/src/xml/ExpatXMLParser.cpp",
-                      "svgnative/src/xml/RapidXMLParser.cpp",
+                      "svgnative/src/xml/LibXMLParser.cpp",
                       "svgnative/src/ports/cairo",
                       "svgnative/src/ports/d2d",
                       "svgnative/src/ports/gdiplus",

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             dependencies: ["boost", "cpp-base64"],
             path: "svg-native-viewer",
             exclude: ["svgnative/src/win",
-                      "svgnative/src/xml/ExpatXMLParser.cpp",
+                      "svgnative/src/xml/RapidXMLParser.cpp",
                       "svgnative/src/xml/LibXMLParser.cpp",
                       "svgnative/src/ports/cairo",
                       "svgnative/src/ports/d2d",

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             dependencies: ["boost", "cpp-base64"],
             path: "svg-native-viewer",
             exclude: ["svgnative/src/win",
-                      "svgnative/src/xml/RapidXMLParser.cpp",
+                      "svgnative/src/xml/ExpatXMLParser.cpp",
                       "svgnative/src/xml/LibXMLParser.cpp",
                       "svgnative/src/ports/cairo",
                       "svgnative/src/ports/d2d",

--- a/svgnative.podspec
+++ b/svgnative.podspec
@@ -38,7 +38,7 @@ SVG Native will be a strict subset of SVG 1.1 and SVG 2.0.
   s.public_header_files = 'svg-native-viewer/svgnative/include/**/*.{h,hpp}'
   s.header_mappings_dir = 'svg-native-viewer/svgnative/include'
   s.exclude_files = ['svg-native-viewer/svgnative/src/xml/ExpatXMLParser.cpp',
-                     'svg-native-viewer/svgnative/src/xml/RapidXMLParser.cpp',
+                     'svg-native-viewer/svgnative/src/xml/LibXMLParser.cpp',
                      'svg-native-viewer/svgnative/src/ports/cairo',
                      'svg-native-viewer/svgnative/src/ports/d2d',
                      'svg-native-viewer/svgnative/src/ports/gdiplus',


### PR DESCRIPTION
Having this issue: https://github.com/SDWebImage/SDWebImageSVGNativeCoder/issues/14

Seems to be resolved by using RapidXMLParser instead in my testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the native SVG package’s build configuration by revising the exclusion rules for XML parser components, ensuring a more streamlined integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->